### PR TITLE
Clarified instructions around the external path

### DIFF
--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -49,7 +49,7 @@ In the Immich web UI:
 - Click Add path
   <img src={require('./img/add-path-button.png').default} width="50%" title="Add Path button" />
 
-- Enter **/home/user/photos1** (or whatever the path is after the `:` in your docker compose file) as the path and click Add
+- Enter **/home/user/photos1** (or whatever the path is after the `:` and before the `:ro` in your docker compose file) as the path and click Add
   <img src={require('./img/add-path-field.png').default} width="50%" title="Add Path field" />
 
 - Save the new path


### PR DESCRIPTION
Updated instructions on how to properly implement and use external libraries. Relates to #9777.

This fixes two problems that were identified when I was going through the documentation and setting up external libraries.

- The original documentation states to update the docker-compose.yml in the `immich-server` section only. This causes the path to be validated in the UI, but nothing is ran because the microservices container does not have access to the path. Updated the documentation to show that you need to add it in both places for this to work.
- The original documentation shows `/home/user/photos1` in the docker-compose.yml, but uses `/usr/src/app/external` in the demonstration. The documentation was updated to show that this path should be the same path as the docker-compose.yml